### PR TITLE
fix signTX

### DIFF
--- a/bin/bwallet-cli
+++ b/bin/bwallet-cli
@@ -329,10 +329,10 @@ class CLI {
 
   async signTX() {
     const passphrase = this.config.str('passphrase');
-    const raw = this.config.str([0, 'tx']);
-    const tx = await this.wallet.sign(raw, { passphrase });
+    const tx = this.config.str([0, 'tx']);
+    const signedTX = await this.wallet.sign({tx, passphrase});
 
-    this.log(tx);
+    this.log(signedTX);
   }
 
   async zapWallet() {


### PR DESCRIPTION
was returning this error:
```
$ bwallet-cli sign --id=$id --passphrase=$passphrase --tx=$tx
AssertionError [ERR_ASSERTION]: false == true
    at WalletClient.request (/home/ec2-user/node-v8.11.1-linux-x64/lib/node_modules/bclient/node_modules/bcurl/lib/client.js:164:5)
    at WalletClient.post (/home/ec2-user/node-v8.11.1-linux-x64/lib/node_modules/bclient/node_modules/bcurl/lib/client.js:234:17)
    at WalletClient.sign (/home/ec2-user/node-v8.11.1-linux-x64/lib/node_modules/bclient/lib/wallet.js:357:17)
    at Wallet.sign (/home/ec2-user/node-v8.11.1-linux-x64/lib/node_modules/bclient/lib/wallet.js:793:24)
    at CLI.signTX (/home/ec2-user/node-v8.11.1-linux-x64/lib/node_modules/bclient/bin/bwallet-cli:333:34)
    at CLI.handleWallet (/home/ec2-user/node-v8.11.1-linux-x64/lib/node_modules/bclient/bin/bwallet-cli:545:20)
    at CLI.open (/home/ec2-user/node-v8.11.1-linux-x64/lib/node_modules/bclient/bin/bwallet-cli:676:17)
    at /home/ec2-user/node-v8.11.1-linux-x64/lib/node_modules/bclient/bin/bwallet-cli:687:13
    at Object.<anonymous> (/home/ec2-user/node-v8.11.1-linux-x64/lib/node_modules/bclient/bin/bwallet-cli:690:3)
    at Module._compile (module.js:652:30)
```
This PR updates the syntax to match the neighboring functions, and the API call returns a expected output. NEEDS REVIEW! I'm not sure it's totally doing what it's supposed to!