### PR TITLE
bwallet-cli: password required for createAccount()

### DIFF
--- a/bin/bwallet-cli
+++ b/bin/bwallet-cli
@@ -153,6 +153,7 @@ class CLI {
     const name = this.config.str([0, 'name']);
 
     const options = {
+      passphrase: this.config.str('passphrase'),
       type: this.config.str('type'),
       m: this.config.uint('m'),
       n: this.config.uint('n'),


### PR DESCRIPTION
Kept getting `Error: No passphrase.` trying to create an account with `bwallet-cli`. cURL and JS methods work fine.