### PR TITLE
bwallet-cli: rename mkwallet args to match cURL and JS methods

### DIFF
--- a/bin/bwallet-cli
+++ b/bin/bwallet-cli
@@ -77,8 +77,8 @@ class CLI {
       n: this.config.uint('n'),
       witness: this.config.bool('witness'),
       passphrase: this.config.str('passphrase'),
-      watchOnly: this.config.has('key') ? true : this.config.bool('watch'),
-      accountKey: this.config.str('key')
+      watchOnly: this.config.has('key') ? true : this.config.bool('watchOnly'),
+      accountKey: this.config.str('accountKey')
     };
 
     const wallet = await this.client.createWallet(id, options);


### PR DESCRIPTION
http://bcoin.io/api-docs/#configuration

List of args should be consistent for all methods. Don't know if there's a reason why `accountKey` and `watchOnly` are slightly different for CLI. Docs are currently accurate in the examples under the CLI tab, but will need an update if this PR is merged.