### PR TITLE
bwallet-cli: require account-key if watch-only

### DIFF
--- a/bin/bwallet-cli
+++ b/bin/bwallet-cli
@@ -83,6 +83,11 @@ class CLI {
       accountKey: this.config.str('account-key')
     };
 
+    if (options.watchOnly && !options.accountKey) {
+      this.log('Account key required when creating watch-only wallet');
+      return;
+    }
+
     const wallet = await this.client.createWallet(id, options);
 
     this.log(wallet);


### PR DESCRIPTION
Addresses possible user error and confusion regarding purpose of watch-only wallets. Not passing an `xpub` results in a wallet with private keys (bcoin wallet will still generate a master private key) but being watch-only, it will refuse to dump private keys or sign transactions. 

See https://github.com/bcoin-org/bcoin/issues/636