### PR TITLE
Emit using eventEmitter

### DIFF
--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -72,6 +72,8 @@ class WalletClient extends Client {
 
     if (wallet)
       wallet.emit(event, ...args);
+
+    this.emit(event, id, ...args);
   }
 
   /**


### PR DESCRIPTION
Even though you can use `bind` for WalletClient to subscribe to events, we end up having different APIs for Wallet and WalletClient (One using `bind` another `on`).

This will enable EventEmitter api for walletClient. (EventEmitter is used for connect, error and disconnect events for now).
