### PR TITLE
wallet: expose wallet class so it is extendable

### DIFF
--- a/lib/bclient.js
+++ b/lib/bclient.js
@@ -7,4 +7,6 @@
 'use strict';
 
 exports.NodeClient = require('./node');
-exports.WalletClient = require('./wallet');
+
+const {WalletClient} = require('./wallet');
+exports.WalletClient = WalletClient;

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -610,7 +610,9 @@ class WalletClient extends Client {
 class Wallet extends EventEmitter {
   /**
    * Create a wallet client.
-   * @param {Object?} options
+   * @param {WalletClient} parent
+   * @param {String} id
+   * @param {String} token
    */
 
   constructor(parent, id, token) {
@@ -1040,4 +1042,4 @@ class Wallet extends EventEmitter {
  * Expose
  */
 
-module.exports = WalletClient;
+module.exports =  { WalletClient, Wallet };


### PR DESCRIPTION
This allows wallet plugins to extend existing Wallet client more easily, without duplicate code.

Example: https://github.com/bcoin-org/bmultisig-client

Concerns: This does result in a breaking change for anything that requires `bclient/lib/wallet`. Currently the majority of cases I looked into simply require `bclient`, which I have intentionally left unchanged.
