### PR TITLE
RPC: force help if no method

### DIFF
--- a/bin/bcoin-cli
+++ b/bin/bcoin-cli
@@ -141,8 +141,11 @@ class CLI {
   }
 
   async rpc() {
-    const method = this.argv.shift();
+    let method = this.argv.shift();
     const params = [];
+
+    if (!method)
+      method = 'help';
 
     for (const arg of this.argv) {
       let param;
@@ -204,7 +207,7 @@ class CLI {
         this.log('  $ coin [hash+index/address]: View coins.');
         this.log('  $ block [hash/height]: View block.');
         this.log('  $ reset [height/hash]: Reset chain to desired block.');
-        this.log('  $ rpc [command] [args]: Execute RPC command.' + 
+        this.log('  $ rpc [command] [args]: Execute RPC command.' +
           ' (`bcoin-cli rpc help` for more)');
         break;
     }

--- a/bin/bwallet-cli
+++ b/bin/bwallet-cli
@@ -452,8 +452,11 @@ class CLI {
   }
 
   async rpc() {
-    const method = this.argv.shift();
+    let method = this.argv.shift();
     const params = [];
+
+    if (!method)
+      method = 'help';
 
     for (const arg of this.argv) {
       let param;


### PR DESCRIPTION
Replaces https://github.com/bcoin-org/bcurl/pull/7

Possible alternate for #19 

If no rpc method is provided, `help` is automatically swapped in, eventually should display a list of rpc commands like in https://github.com/bcoin-org/bcoin/pull/705 or https://github.com/bcoin-org/bcoin/pull/550