### PR TITLE
node client: add method for fetching block header

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -147,6 +147,17 @@ class NodeClient extends Client {
   }
 
   /**
+   * Retrieve a block header.
+   * @param {Hash|Number} block
+   * @returns {Promise}
+   */
+
+  getBlockHeader(block) {
+    assert(typeof block === 'string' || typeof block === 'number');
+    return this.get(`/header/${block}`);
+  }
+
+  /**
    * Add a transaction to the mempool and broadcast it.
    * @param {TX} tx
    * @returns {Promise}


### PR DESCRIPTION
Adds a method for fetching block headers.
Corresponding PR in bcoin - https://github.com/bcoin-org/bcoin/pull/808